### PR TITLE
Feat/40+47 create progress bar & fixed progress bug

### DIFF
--- a/src/pages/quiz.js
+++ b/src/pages/quiz.js
@@ -120,9 +120,9 @@ const showResults = () => {
         </div>
 
         {/* PROGRESS BAR */}
-        <div>
+        <div className={styles.progress_wrapper}>
           <ProgressBar progress={progress} />
-          <h3>{`${currentQuestion + 1} / ${content.length}`}</h3>
+          <h3 className={styles.progress_text}>{`${currentQuestion + 1} / ${content.length}`}</h3>
         </div>
       </main>
     </>

--- a/src/pages/quiz.js
+++ b/src/pages/quiz.js
@@ -101,11 +101,11 @@ const showResults = () => {
           {/* ANSWERS INPUTS */}
           {content[currentQuestion].quizAnswers.map((answer, index )=> (
               <div key={index} className="answers">
-                <input type="radio" name={answer.answer} value={answer.answer}
+                <input id={`theInput-${index}`} type="radio" name={answer.answer} value={answer.answer}
                 onChange ={(e) => handleSelectedAnswer(answer.answer)}
-                checked ={answer.answer === selectedAnswer[currentQuestion]?.userAnswer}
-                className={styles.answerBtns}/> 
-                <label className={styles.inputDesign}>i</label>
+                checked = {answer.answer === selectedAnswer[currentQuestion]?.userAnswer}
+                className={styles.answerBtns}/>
+                <label for ={`theInput-${index}`} className={styles.inputDesign}></label>
               </div>
           ))}
 

--- a/src/pages/quiz.js
+++ b/src/pages/quiz.js
@@ -14,7 +14,7 @@ export default function Quiz({updateFormData}) {
 
 const [currentQuestion, setCurrentQuestion] = useState(0);
 const [selectedAnswer, setSelectedAnswer] = useState([]);
-const [progress, setProgress] = useState(0); // new addition 4/8/23
+const [progress, setProgress] = useState(33.33); // number placeholder
 
 const { answer, setAnswer } = useContext(Results_data);
 var router = useRouter();
@@ -32,7 +32,6 @@ const clickNext = () => {
   const nextQuestion = currentQuestion + 1;
   nextQuestion < content.length && setCurrentQuestion(nextQuestion);
   const progress = (((currentQuestion +1) + 1) / content.length) * 100;
-
   setProgress(progress); // new addition 4/8/23
 };
 
@@ -105,7 +104,8 @@ const showResults = () => {
                 <input type="radio" name={answer.answer} value={answer.answer}
                 onChange ={(e) => handleSelectedAnswer(answer.answer)}
                 checked ={answer.answer === selectedAnswer[currentQuestion]?.userAnswer}
-                className={styles.answerBtns}/>
+                className={styles.answerBtns}/> 
+                <label className={styles.inputDesign}>i</label>
               </div>
           ))}
 

--- a/src/styles/Quiz.module.css
+++ b/src/styles/Quiz.module.css
@@ -9,6 +9,7 @@
   .quiz_statement {
     margin-top: 3rem;
     color: black;
+    margin-bottom: 5rem;
   }
 
   .answer_titles{
@@ -31,30 +32,28 @@
 
   .inputDesign {
     display: flex;
-    color: lightskyblue;
     font-size: 25px;
-    border: 2px solid lightskyblue;
-    padding: 10px 50px;
+    padding: 5px 15px;
    }
 
    .inputDesign:before {
     content: "";
-    height: 25px;
-    width: 25px;
-    border: 3px solid lightgreen;
+    height: 35px;
+    width: 35px;
+    border: 2px solid #000000;
+    background-color: #D9D9D9;
     border-radius: 50%;
     margin-right: 10px;
    }
 
    .answerBtns:checked + .inputDesign{
-    background-color: lightgreen;
     color: white;
    }
 
    .answerBtns:checked + .inputDesign:before{
-    height: 14px;
-    width: 14px;
-    border: 8px solid white;
+    height: 35px;
+    width: 35px;
+    background-color: #565656;
    }
 
   .next_btn{

--- a/src/styles/Quiz.module.css
+++ b/src/styles/Quiz.module.css
@@ -7,9 +7,10 @@
   }
 
   .quiz_statement {
-    margin-top: 3rem;
+    margin-top: 1rem;
+    width: 80vw;
     color: black;
-    margin-bottom: 5rem;
+    margin-bottom: 7rem;
   }
 
   .answer_titles{
@@ -38,8 +39,8 @@
 
    .inputDesign:before {
     content: "";
-    height: 35px;
-    width: 35px;
+    height: 37px;
+    width: 37px;
     border: 2px solid #000000;
     background-color: #D9D9D9;
     border-radius: 50%;
@@ -51,8 +52,8 @@
    }
 
    .answerBtns:checked + .inputDesign:before{
-    height: 35px;
-    width: 35px;
+    height: 37px;
+    width: 37px;
     background-color: #565656;
    }
 
@@ -89,22 +90,33 @@
   }
 
   .scale_btn{
-    padding-left: 30px;
-    padding-right: 30px;
+    padding-left: 40px;
+    padding-right: 40px;
+  }
+
+  .progress_wrapper{
+    display: flex;
+    margin-top: 25vh;
+    justify-content: space-between;
+    align-items: center;
+
   }
 
  .progress_bar{
-  margin-top: 13rem;
-  width: 70rem;
-  height: 0.75rem;
+  width: 80vw;
+  height: 1rem;
   background-color: #D9D9D9;
   border-radius: 10px;
  }
 
  .user_progress{
   width: 0%;
-  height: 0.75rem;
+  height: 1rem;
   background-color: #2D2D2D;
   border-radius: 10px;
+ }
+
+ .progress_text{
+  margin-left: 1vw;
  }
 

--- a/src/styles/Quiz.module.css
+++ b/src/styles/Quiz.module.css
@@ -20,13 +20,42 @@
     align-items: center;
   } 
 
-  .answerBtns{
-    margin-top: 2rem;
+  .answerBtns {
+    display: none;
+    /*margin-top: 2rem;
     width: 35px;
     height: 35px;
     text-align: center;
-    accent-color: gray;
+    accent-color: gray; */
   }
+
+  .inputDesign {
+    display: flex;
+    color: lightskyblue;
+    font-size: 25px;
+    border: 2px solid lightskyblue;
+    padding: 10px 50px;
+   }
+
+   .inputDesign:before {
+    content: "";
+    height: 25px;
+    width: 25px;
+    border: 3px solid lightgreen;
+    border-radius: 50%;
+    margin-right: 10px;
+   }
+
+   .answerBtns:checked + .inputDesign{
+    background-color: lightgreen;
+    color: white;
+   }
+
+   .answerBtns:checked + .inputDesign:before{
+    height: 14px;
+    width: 14px;
+    border: 8px solid white;
+   }
 
   .next_btn{
     color: white;
@@ -80,19 +109,3 @@
   border-radius: 10px;
  }
 
- .exit_button {
-  padding: 5px 22px 5px 22px;
-  border-radius: 15px;
-  background-color: none;
-  border: none;
-  font-size: 17px;
-  box-shadow: 1px 2px 2px 1px #bdbdbd;
-  font-weight: 600;
-  transition-duration: 0.4s;
-  text-decoration: none;
-  color: black;
- }
-
- .exit_button:hover{
-  background-color: #979797;
- }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #[40](https://github.com/cherryontech/burnout-buster/issues/40) & #[47](https://github.com/cherryontech/burnout-buster/issues/47)

``` javascript
const [progress, setProgress] = useState(33.33); // number placeholder
```

### This is part of what user story/story card (jira)?
N/A


### What changed, and why?
Fixed the loading bug issue we had where the first question didn't have a current status. Also tweaked the overall spacing/styling of the progress bar as well. Although the semantic bar radio buttons are not apart of this issue, I fixed the styling on those to make them match the mid-fi design along with working a bit on the responsiveness of it as well. 

### How is this tested? (please write tests!) 💖💪
None at moment

### Screenshots please
<img width="1436" alt="Screenshot 2023-04-22 at 7 44 55 PM" src="https://user-images.githubusercontent.com/92768477/233816775-31d6cca9-7c4d-41f6-91ec-4f8acc476431.png">


### Are there any gotchas, anything you would like to add?
- The bug fix is currently temporary and will need further work on, so I'm categorizing it as a WIP. For the time being it works lol! 